### PR TITLE
parallel and earlier should accept array-like argument

### DIFF
--- a/jsdeferred.js
+++ b/jsdeferred.js
@@ -450,14 +450,20 @@ Deferred.call = function (fun) {
  * @see Deferred.earlier
  */
 Deferred.parallel = function (dl) {
-	if (arguments.length > 1) dl = Array.prototype.slice.call(arguments);
+	var isArray = false;
+	if (arguments.length > 1) {
+		dl = Array.prototype.slice.call(arguments);
+		isArray = true;
+	} else if (Array.isArray && Array.isArray(dl) || typeof dl.length == "number") {
+		isArray = true;
+	}
 	var ret = new Deferred(), values = {}, num = 0;
 	for (var i in dl) if (dl.hasOwnProperty(i)) (function (d, i) {
 		if (typeof d == "function") d = Deferred.next(d);
 		d.next(function (v) {
 			values[i] = v;
 			if (--num <= 0) {
-				if (dl instanceof Array) {
+				if (isArray) {
 					values.length = dl.length;
 					values = Array.prototype.slice.call(values, 0);
 				}
@@ -487,12 +493,18 @@ Deferred.parallel = function (dl) {
  * @see Deferred.parallel
  */
 Deferred.earlier = function (dl) {
-	if (arguments.length > 1) dl = Array.prototype.slice.call(arguments);
+	var isArray = false;
+	if (arguments.length > 1) {
+		dl = Array.prototype.slice.call(arguments);
+		isArray = true;
+	} else if (Array.isArray && Array.isArray(dl) || typeof dl.length == "number") {
+		isArray = true;
+	}
 	var ret = new Deferred(), values = {}, num = 0;
 	for (var i in dl) if (dl.hasOwnProperty(i)) (function (d, i) {
 		d.next(function (v) {
 			values[i] = v;
-			if (dl instanceof Array) {
+			if (isArray) {
 				values.length = dl.length;
 				values = Array.prototype.slice.call(values, 0);
 			}


### PR DESCRIPTION
JSDeferredが専用の名前空間に読み込まれてて、他の名前空間からJSDeferredのparallelを利用したときに、parallelの単一の引数としてArrayを渡した場合でも次のnextで渡ってくる値がArrayにならないという問題に遭遇しました。
原因は、引数がArrayかどうかの判定をinstanceofで行っているためです。
そこで、Array.isArrayが利用可能な場合はそれを使って判定し、なければlengthプロパティの有無で判定するという風にしてみました。

この方法のデメリットは、単一の引数としてArrayではないlengthプロパティを持ったオブジェクト（NodeListなど）を渡した場合にまでArrayと誤判定されてしまうという点です。実際のユースケースを考えるとこれでも問題ないのではないかと思っていますが、厳密さ・安全性という意味では元の版より後退している事になりますので、却下されても仕方がないとは思っております……
