### PR TITLE
Fixed scope of the canceller is from becoming the window

### DIFF
--- a/jsdeferred.js
+++ b/jsdeferred.js
@@ -189,7 +189,7 @@ Deferred.prototype = {
 	 * @return {Deferred} this
 	 */
 	cancel : function () {
-		(this.canceller || function () {})();
+		(this.canceller || function () {}).apply(this);
 		return this.init();
 	},
 


### PR DESCRIPTION
cancel時、cancellerのスコープがwindowになってしまうので修正しました。

``` Javascript
var d = new Deferred();
d.canceller = function(){
  console.log(this); //=> window
}
d.cancel();
```
